### PR TITLE
Add Basic Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,20 @@ export PORT=1234
 export LOGINAPI=https://user:password@login.webmaker.org
 export COOKIE_SECRET=topSecretPasswordForEncryptingCookies
 export SECURE_COOKIES=true
+export GA_TRACKING_ID='UA-000000-01'
+export GA_DEBUG='on'
 ```
 
 You can configure the following environment variables:
 
-```
-HOST - host for this server. defaults to 0.0.0.0
-PORT - port of this server, defaults to 0 (a random port above 1024)
-LOGINAPI - fully qualified login.wm.org URL e.g. https://user:password@login.webmaker.org
-OAUTH_DB - JSON array of oauth clients e.g.
-  [{"client_id":"test","secret":"test","redirect_uri":"http://localhost:3000/account"}]
-COOKIE_SECRET - A String value used to encrypt session cookies
-SECURE_COOKIES - set to `true` to indicate that the user agent should transmit the cookie only over a secure channel
+|Variable|About|
+|--------|-----|
+| HOST | host for this server. defaults to 0.0.0.0 |
+| PORT | port of this server, defaults to 0 (a random port above 1024) |
+| LOGINAPI | fully qualified login.wm.org URL e.g. https://user:password@login.webmaker.org |
+| OAUTH_DB | JSON array of oauth clients e.g. [{"client_id":"test", "secret":"test", "redirect_uri":"http://localhost:3000/account"}] |
+| COOKIE_SECRET | A String value used to encrypt session cookies |
+| SECURE_COOKIES | set to `true` to indicate that the user agent should transmit the cookie only over a secure channel |
+| GA_TRACKING_ID | The tracking ID is a string like UA-000000-01 [more](https://support.google.com/analytics/answer/1032385?hl=en) |
+| GA_DEBUG | if set to 'on' will enable debug logging to the console in `react-ga` |
 ```

--- a/package.json
+++ b/package.json
@@ -6,22 +6,17 @@
   "scripts": {
     "start": "parallelshell \"node web/index.js\" \"npm run watch:css\" \"npm run watch:js\"",
     "test": "npm run test:server && npm run test:browser && npm run lint",
-
     "build": "npm run build:css && npm run build:js",
     "build:css": "npm run watch:css -- --no-watch",
     "build:js": "webpack --config webpack.config.js --progress --profile --colors",
-
     "jscs": "jscs lib test web *.js",
     "jshint": "jshint lib test web *.js",
     "jsbeautify": "js-beautify lib test web *.js -r",
     "lint": "npm run jshint && npm run jscs",
-
     "postinstall": "npm run build",
-
     "pretest:browser": "ncp node_modules/mocha/mocha.js public/tests/mocha.js && ncp node_modules/mocha/mocha.css public/tests/mocha.css",
     "test:browser": "npm run build && mocha-phantomjs -s loadImages=false public/tests/index.html",
     "test:server": "lab -t 95",
-
     "watch:js": "npm run build:js -- --watch",
     "watch:css": "autoless --source-map templates/less public"
   },
@@ -55,6 +50,7 @@
     "joi": "^6.0.8",
     "jsx-loader": "^0.12.2",
     "react": "^0.12.2",
+    "react-ga": "^1.0.8",
     "react-router": "^0.12.4",
     "react-router-stub": "0.0.5",
     "react-validation-mixin": "^4.0.3",

--- a/templates/lib/routes.jsx
+++ b/templates/lib/routes.jsx
@@ -3,6 +3,11 @@ var Router = require('react-router');
 var Route = Router.Route;
 var Link = Router.Link;
 var NotFoundRoute = Router.NotFoundRoute;
+var ga = require('react-ga');
+
+// TODO: this is a dummy GA tracking ID until the real one is ready
+var gaTrackingID = process.env.GA_TRACKING_ID || 'UA-59356678-5';
+var gaDebug = process.env.GA_DEBUG || 'off';
 
 var routes = (
   <Route>
@@ -17,7 +22,13 @@ var routes = (
 module.exports = {
   routes: routes,
   run: function(location, el) {
+    var options = {};
+    if (gaDebug === 'on') {
+      options.debug = true;
+    }
+    ga.initialize(gaTrackingID, options);
     Router.run(routes, location, function(Handler, state) {
+      ga.pageview(state.pathname);
       React.render(<Handler/>, el);
     });
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,9 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin(importEnvVars([
-      // TODO: Define any variable we want to expose to the client here.
+      // Any variables we want to expose to the client:
+      'GA_TRACKING_ID',
+      'GA_DEBUG'
     ]))
   ]
 };


### PR DESCRIPTION
This is the first of many metrics requirements, as recorded in https://github.com/mozilla/id.webmaker.org/issues/77

Adds the `react-ga` module, and implements basic pageview tracking using `react-router`.