### PR TITLE
Fix OAUTH_DB example value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can configure the following environment variables:
 | HOST | host for this server. defaults to 0.0.0.0 |
 | PORT | port of this server, defaults to 0 (a random port above 1024) |
 | LOGINAPI | fully qualified login.wm.org URL e.g. https://user:password@login.webmaker.org |
-| OAUTH_DB | JSON array of oauth clients e.g. [{"client_id":"test", "secret":"test", "redirect_uri":"http://localhost:3000/account"}] |
+| OAUTH_DB | JSON array of oauth clients e.g. [{"client_id":"test", "client_secret":"test", "redirect_uri":"http://localhost:3000/account"}] |
 | COOKIE_SECRET | A String value used to encrypt session cookies |
 | SECURE_COOKIES | set to `true` to indicate that the user agent should transmit the cookie only over a secure channel |
 | URI | The URI where the server is reachable at, used for reset email links |


### PR DESCRIPTION
It seems the current implementation is actually looking at the `client_secret` key, not the `secret` key.

I also recommend doing some basic validation in the `oauth-db.js` file to ensure that the JSON blob is well-formed, to avoid having to debug things like this further down the pipeline.