### PR TITLE
Bump version of react-ga

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jsx-loader": "^0.12.2",
     "pass-test": "0.0.5",
     "react": "^0.12.2",
-    "react-ga": "^1.0.8",
+    "react-ga": "^1.0.10",
     "react-router": "^0.12.4",
     "react-router-stub": "0.0.5",
     "react-router-viewports": "0.0.4",


### PR DESCRIPTION
r?

I fixed a bug in `react-ga` today which was stopping the 'labels' from being recorded in GA events.