### PR TITLE
Fix issue #317 - Change from username to email for password recovery …

### DIFF
--- a/templates/components/request-reset-view.jsx
+++ b/templates/components/request-reset-view.jsx
@@ -8,10 +8,10 @@ var API = require('../lib/api.jsx');
 
 var fields = [
   {
-    'username': {
-      'placeholder': 'Username',
+    'email': {
+      'placeholder': 'Email',
       'type': 'text',
-      'validator': 'username'
+      'validator': 'email'
     }
   }
 ];
@@ -31,11 +31,9 @@ var RequestResetPassword = React.createClass({
     WebmakerActions.deleteListener('FORM_VALIDATION', this.handleFormData);
   },
   render: function() {
-    var username = this.getQuery().username;
     return (
       <div className="requestPassword innerForm centerDiv">
-        <Form defaultUsername={username}
-              onInputBlur={this.handleBlur}
+        <Form onInputBlur={this.handleBlur}
               origin="Reset Password"
               ref="userform"
               fields={fields}
@@ -49,7 +47,7 @@ var RequestResetPassword = React.createClass({
     this.props.submitForm(data);
   },
   handleBlur: function(fieldName, value) {
-    if ( fieldName === 'username' && value ) {
+    if ( fieldName === 'email' && value ) {
       this.checkUsername(value);
     }
   },

--- a/templates/pages/login.jsx
+++ b/templates/pages/login.jsx
@@ -67,7 +67,7 @@ var Login = React.createClass({
                 defaultUsername={this.queryObj.username}
           />
           <button onClick={this.processFormData} className="btn btn-awsm">{buttonText}</button>
-          <Link onClick={this.handleGA.bind(this, 'Forgot your password')} to="reset-password" query={this.queryObj} className="need-help">Forgot your password?</Link>
+          <Link onClick={this.handleGA.bind(this, 'Forgot your password')} to="reset-password" className="need-help">Forgot your password?</Link>
         </div>
       </div>
     );

--- a/templates/pages/reset-password.jsx
+++ b/templates/pages/reset-password.jsx
@@ -124,7 +124,7 @@ var ResetPassword = React.createClass({
         'X-CSRF-Token': csrfToken
       },
       body: JSON.stringify({
-        uid: data.username,
+        uid: data.email,
         oauth: Url.parse(window.location.href, true).query
       })
     }).then(function(response) {


### PR DESCRIPTION
Closes #317 

In this patch I've changed from username to email to recovery password, and I also remove query that we are passing from login page since that could be a username which we are no longer allowed on password recovery page.

