### PR TITLE
Make lang an optional attribute for create user

### DIFF
--- a/test/mock-login/server.js
+++ b/test/mock-login/server.js
@@ -87,7 +87,8 @@ module.exports = function() {
           return reply({
             user: {
               username: 'webmaker',
-              email: 'webmaker@example.com'
+              email: 'webmaker@example.com',
+              prefLocale: payload.user.prefLocale || 'en-US'
             }
           })
           .type('application/json');

--- a/test/web.js
+++ b/test/web.js
@@ -129,6 +129,67 @@ lab.experiment("OAuth", function() {
     });
   });
 
+  lab.test("POST Create User without lang attribute defaults to en-US", function(done) {
+    ls.start(function(error) {
+      Code.expect(error).to.be.undefined();
+      var request = {
+        method: "POST",
+        url: "/create-user",
+        headers: {
+          "Cookie": "crumb=02mke0occKoOiqFkr9MUYo9YnMellJE_0dPD6UowyeJ",
+          "X-CSRF-Token": "02mke0occKoOiqFkr9MUYo9YnMellJE_0dPD6UowyeJ"
+        },
+        payload: {
+          email: "webmaker@example.com",
+          username: "webmaker",
+          password: "CantGuessThis123",
+          feedback: true,
+          client_id: "test"
+        }
+      };
+
+      s2.inject(request, function(response) {
+        Code.expect(response.statusCode).to.equal(200);
+        Code.expect(response.headers["set-cookie"]).to.exist();
+        Code.expect(response.result.email).to.equal("webmaker@example.com");
+        Code.expect(response.result.username).to.equal("webmaker");
+        Code.expect(response.result.prefLocale).to.equal("en-US");
+        ls.stop(done);
+      });
+    });
+  });
+
+  lab.test("POST Create User with lang attribute set", function(done) {
+    ls.start(function(error) {
+      Code.expect(error).to.be.undefined();
+      var request = {
+        method: "POST",
+        url: "/create-user",
+        headers: {
+          "Cookie": "crumb=02mke0occKoOiqFkr9MUYo9YnMellJE_0dPD6UowyeJ",
+          "X-CSRF-Token": "02mke0occKoOiqFkr9MUYo9YnMellJE_0dPD6UowyeJ"
+        },
+        payload: {
+          email: "webmaker@example.com",
+          username: "webmaker",
+          password: "CantGuessThis123",
+          feedback: true,
+          client_id: "test",
+          lang: "it-CH"
+        }
+      };
+
+      s2.inject(request, function(response) {
+        Code.expect(response.statusCode).to.equal(200);
+        Code.expect(response.headers["set-cookie"]).to.exist();
+        Code.expect(response.result.email).to.equal("webmaker@example.com");
+        Code.expect(response.result.username).to.equal("webmaker");
+        Code.expect(response.result.prefLocale).to.equal("it-CH");
+        ls.stop(done);
+      });
+    });
+  });
+
   lab.test("POST Create User (invalid response)", function(done) {
     ls.start(function(error) {
       Code.expect(error).to.be.undefined();

--- a/web/server.js
+++ b/web/server.js
@@ -408,7 +408,7 @@ module.exports = function(options) {
             password: Joi.string().regex(/^\S{8,128}$/).required(),
             feedback: Joi.boolean().required(),
             client_id: Joi.string().required(),
-            lang: Joi.string().required()
+            lang: Joi.string().default('en-US')
           },
           failAction: function(request, reply, source, error) {
             reply(Boom.badRequest('invalid ' + source + ': ' + error.data.details[0].path));


### PR DESCRIPTION
lang must be an optional attribute for compatibility with older clients.
If we default to to en-US we get the desired behaviour: en-US for old
clients and new clients can set their preferred locale.

Fix https://github.com/mozilla/webmaker-core/issues/423 .