### PR TITLE
Add null check for error-handling

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -103,6 +103,7 @@ module.exports = function(options) {
   function isUniqueError(fieldName, err) {
     // SQLite and MariaDB/MySQL have conflicting error messages, and we don't know which DB the login server is using
     if (
+      err &&
       // SQLite
       err.indexOf('Users.' + fieldName) !== -1 ||
       (


### PR DESCRIPTION
We found the following traceback with NewRelic:

```
TypeError: undefined is not a function
at isUniqueError (/app/web/server.js:107:11)
at /app/web/server.js:505:18
at /app/lib/account.js:139:11
at IncomingMessage.<anonymous> (/app/lib/account.js:46:7)
at IncomingMessage.emit (events.js:129:20)
at IncomingMessage.wrapped (/app/node_modules/newrelic/lib/transaction/tracer/index.js:157:28)
at IncomingMessage.wrappedEmit [as emit] (/app/node_modules/newrelic/lib/transaction/tracer/index.js:197:46)
at _stream_readable.js:908:16
at wrapped (/app/node_modules/newrelic/lib/transaction/tracer/index.js:157:28)
at process._tickDomainCallback (node.js:381:11)
```

Which corresponds to https://github.com/mozilla/id.webmaker.org/blob/3f60934d119a28977e0399772ee9dc44bdebe8d6/web/server.js#L107

Just need to add a null check