### PR TITLE
Login caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can configure the following environment variables:
 | GA_DEBUG | if set to 'on' will enable debug logging to the console in `react-ga` |
 | OPTIMIZELY_ID | Optimizely Project ID (not a secret) e.g. '206878104' |
 | OPTIMIZELY_ACTIVE | If set to 'yes' (String) the project will include Optimizely snippet in the page load |
+| REDIS_URL | URL of a redis server to use for caching. If unset, an in-memory cache will be used instead. |
 
 ## Using OAuth2
 

--- a/lib/account.js
+++ b/lib/account.js
@@ -158,6 +158,7 @@ exports.register = function(server, options, next) {
   });
 
   server.method('account.getUser', function(userId, callback) {
+    var ttl = null;
     var getRequest = hyperquest({
       method: 'GET',
       headers: {
@@ -166,13 +167,26 @@ exports.register = function(server, options, next) {
       uri: loginAPI + '/user/id/' + userId
     });
 
-    getRequest.on('error', callback);
+    getRequest.on('error', function(err) {
+      callback(err, null, 0);
+    });
 
     getRequest.on('response', function(message) {
       parseMessage(message, function(err, json) {
-        callback(err, json);
+        if (json && !json.user) {
+          ttl = 0;
+        }
+
+        callback(err, json, ttl);
       });
     });
+  }, {
+    cache: {
+      segment: 'accounts.getUser',
+      expiresIn: 1000 * 60 * 60 * 24,
+      staleIn:  1000 * 60 * 60,
+      staleTimeout: 100
+    }
   });
 
   server.method('account.requestMigrateEmail', function(request, callback) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -2,269 +2,281 @@ var Boom = require('boom');
 var hyperquest = require('hyperquest');
 var url = require('url');
 
-module.exports = function(config) {
-  // https://basic:auth@login.server.org
-  var loginAPI = config.loginAPI;
-
-  function getIPAddress(request) {
-    // account for load balancer!
-    if (request.headers['x-forwarded-for']) {
-      return request.headers['x-forwarded-for'];
-    }
-
-    return request.info.remoteAddress;
+function getIPAddress(request) {
+  // account for load balancer!
+  if (request.headers['x-forwarded-for']) {
+    return request.headers['x-forwarded-for'];
   }
 
-  function parseMessage(message, callback) {
-    var bodyParts = [];
-    var bytes = 0;
+  return request.info.remoteAddress;
+}
 
-    message.on('data', function(c) {
-      bodyParts.push(c);
-      bytes += c.length;
-    });
+function parseMessage(message, callback) {
+  var bodyParts = [];
+  var bytes = 0;
 
-    message.on('end', function() {
-      var body = Buffer.concat(bodyParts, bytes).toString('utf8');
-      var json;
+  message.on('data', function(c) {
+    bodyParts.push(c);
+    bytes += c.length;
+  });
 
-      if ( message.statusCode !== 200 ) {
-        try {
-          json = JSON.parse(body);
-        } catch (ex) {
-          return callback(Boom.create(message.statusCode, 'LoginAPI error', body));
-        }
-        return callback(Boom.create(message.statusCode, 'LoginAPI error', json));
-      }
+  message.on('end', function() {
+    var body = Buffer.concat(bodyParts, bytes).toString('utf8');
+    var json;
 
+    if ( message.statusCode !== 200 ) {
       try {
         json = JSON.parse(body);
       } catch (ex) {
-        return callback(Boom.badImplementation('Error parsing response from Login server', ex));
+        return callback(Boom.create(message.statusCode, 'LoginAPI error', body));
       }
-
-      callback(null, json);
-    });
-  }
-
-  return {
-    verifyPassword: function(request, callback) {
-      var loginRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/verify-password'
-      });
-
-      loginRequest.on('error', callback);
-
-      loginRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      loginRequest.end(JSON.stringify({
-        password: request.payload.password,
-        uid: request.payload.uid,
-        user: {}
-      }), 'utf8');
-    },
-    requestReset: function(request, callback) {
-      var appURLObj = url.parse(config.uri + '/reset-password', true);
-      appURLObj.query = request.payload.oauth;
-
-      var resetRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/request-reset-code'
-      });
-
-      resetRequest.on('error', callback);
-
-      resetRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      resetRequest.end(JSON.stringify({
-        uid: request.payload.uid,
-        appURL: url.format(appURLObj)
-      }), 'utf8');
-    },
-    resetPassword: function(request, callback) {
-      var resetRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/reset-password'
-      });
-
-      resetRequest.on('error', callback);
-
-      resetRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      resetRequest.end(JSON.stringify({
-        uid: request.payload.uid,
-        resetCode: request.payload.resetCode,
-        newPassword: request.payload.password
-      }), 'utf8');
-    },
-    createUser: function(request, callback) {
-      var createRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/create'
-      });
-
-      createRequest.on('error', callback);
-
-      createRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      createRequest.end(JSON.stringify({
-        user: {
-          email: request.payload.email,
-          username: request.payload.username,
-          mailingList: request.payload.feedback,
-          prefLocale: request.payload.lang
-        },
-        oauth: {
-          client_id: request.payload.client_id
-        },
-        password: request.payload.password,
-        audience: config.uri
-      }), 'utf8');
-    },
-    getUser: function(userId, callback) {
-      var getRequest = hyperquest({
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        uri: loginAPI + '/user/id/' + userId
-      });
-
-      getRequest.on('error', callback);
-
-      getRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-    },
-    requestMigrateEmail: function(request, callback) {
-      var appURLObj = url.parse(config.uri + '/migrate', true);
-      appURLObj.query = request.payload.oauth;
-
-      var migrateRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/request'
-      });
-
-      migrateRequest.on('error', callback);
-
-      migrateRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      migrateRequest.end(JSON.stringify({
-        uid: request.payload.uid,
-        appURL: url.format(appURLObj),
-        migrateUser: true
-      }), 'utf8');
-    },
-    verifyToken: function(request, callback) {
-      var verifyRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/authenticateToken'
-      });
-
-      verifyRequest.on('error', callback);
-
-      verifyRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      verifyRequest.end(JSON.stringify({
-        uid: request.pre.uid,
-        token: request.payload.token
-      }), 'utf8');
-    },
-    setPassword: function(request, uid, password, callback) {
-      var passwordRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/enable-passwords'
-      });
-
-      passwordRequest.on('error', callback);
-
-      passwordRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      passwordRequest.end(JSON.stringify({
-        uid: uid,
-        password: password
-      }), 'utf8');
-    },
-    checkUsername: function(request, callback) {
-      var usernameRequest = hyperquest({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-ratelimit-ip': getIPAddress(request)
-        },
-        uri: loginAPI + '/api/v2/user/exists'
-      });
-
-      usernameRequest.on('error', callback);
-
-      usernameRequest.on('response', function(message) {
-        parseMessage(message, function(err, json) {
-          callback(err, json);
-        });
-      });
-
-      usernameRequest.end(JSON.stringify({
-        uid: request.payload.uid
-      }), 'utf8');
+      return callback(Boom.create(message.statusCode, 'LoginAPI error', json));
     }
-  };
+
+    try {
+      json = JSON.parse(body);
+    } catch (ex) {
+      return callback(Boom.badImplementation('Error parsing response from Login server', ex));
+    }
+
+    callback(null, json);
+  });
+}
+
+exports.register = function(server, options, next) {
+  // https://basic:auth@login.server.org
+  var loginAPI = options.loginAPI;
+
+  server.method('account.verifyPassword', function(request, callback) {
+    var loginRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/verify-password'
+    });
+
+    loginRequest.on('error', callback);
+
+    loginRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    loginRequest.end(JSON.stringify({
+      password: request.payload.password,
+      uid: request.payload.uid,
+      user: {}
+    }), 'utf8');
+  });
+
+  server.method('account.requestReset', function(request, callback) {
+    var appURLObj = url.parse(options.uri + '/reset-password', true);
+    appURLObj.query = request.payload.oauth;
+
+    var resetRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/request-reset-code'
+    });
+
+    resetRequest.on('error', callback);
+
+    resetRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    resetRequest.end(JSON.stringify({
+      uid: request.payload.uid,
+      appURL: url.format(appURLObj)
+    }), 'utf8');
+  });
+
+  server.method('account.resetPassword', function(request, callback) {
+    var resetRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/reset-password'
+    });
+
+    resetRequest.on('error', callback);
+
+    resetRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    resetRequest.end(JSON.stringify({
+      uid: request.payload.uid,
+      resetCode: request.payload.resetCode,
+      newPassword: request.payload.password
+    }), 'utf8');
+  });
+
+  server.method('account.createUser', function(request, callback) {
+    var createRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/create'
+    });
+
+    createRequest.on('error', callback);
+
+    createRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    createRequest.end(JSON.stringify({
+      user: {
+        email: request.payload.email,
+        username: request.payload.username,
+        mailingList: request.payload.feedback,
+        prefLocale: request.payload.lang
+      },
+      oauth: {
+        client_id: request.payload.client_id
+      },
+      password: request.payload.password,
+      audience: options.uri
+    }), 'utf8');
+  });
+
+  server.method('account.getUser', function(userId, callback) {
+    var getRequest = hyperquest({
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      uri: loginAPI + '/user/id/' + userId
+    });
+
+    getRequest.on('error', callback);
+
+    getRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+  });
+
+  server.method('account.requestMigrateEmail', function(request, callback) {
+    var appURLObj = url.parse(options.uri + '/migrate', true);
+    appURLObj.query = request.payload.oauth;
+
+    var migrateRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/request'
+    });
+
+    migrateRequest.on('error', callback);
+
+    migrateRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    migrateRequest.end(JSON.stringify({
+      uid: request.payload.uid,
+      appURL: url.format(appURLObj),
+      migrateUser: true
+    }), 'utf8');
+  });
+
+  server.method('account.verifyToken', function(request, callback) {
+    var verifyRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/authenticateToken'
+    });
+
+    verifyRequest.on('error', callback);
+
+    verifyRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    verifyRequest.end(JSON.stringify({
+      uid: request.pre.uid,
+      token: request.payload.token
+    }), 'utf8');
+  });
+
+  server.method('account.setPassword', function(request, uid, password, callback) {
+    var passwordRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/enable-passwords'
+    });
+
+    passwordRequest.on('error', callback);
+
+    passwordRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    passwordRequest.end(JSON.stringify({
+      uid: uid,
+      password: password
+    }), 'utf8');
+  });
+
+  server.method('account.checkUsername', function(request, callback) {
+    var usernameRequest = hyperquest({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-ratelimit-ip': getIPAddress(request)
+      },
+      uri: loginAPI + '/api/v2/user/exists'
+    });
+
+    usernameRequest.on('error', callback);
+
+    usernameRequest.on('response', function(message) {
+      parseMessage(message, function(err, json) {
+        callback(err, json);
+      });
+    });
+
+    usernameRequest.end(JSON.stringify({
+      uid: request.payload.uid
+    }), 'utf8');
+  });
+
+  next();
+};
+
+exports.register.attributes = {
+  name: 'login-webmakerorg'
 };

--- a/lib/account.js
+++ b/lib/account.js
@@ -183,8 +183,8 @@ exports.register = function(server, options, next) {
   }, {
     cache: {
       segment: 'accounts.getUser',
-      expiresIn: 1000 * 60 * 60 * 24,
-      staleIn:  1000 * 60 * 60,
+      expiresIn: 1000 * 60,
+      staleIn:  1000 * 30,
       staleTimeout: 100
     }
   });

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-router-stub": "0.0.6",
     "react-router-viewports": "0.0.4",
     "react-validation-mixin": "^4.0.3",
+    "redis-url": "^1.2.1",
     "scooter": "^2.0.1",
     "should": "^5.2.0",
     "webpack": "^1.7.3"

--- a/web/index.js
+++ b/web/index.js
@@ -15,7 +15,8 @@ var options = {
   uri: process.env.URI,
   enableCSRF: process.env.ENABLE_CSRF !== 'false',
   logging: process.env.LOGGING === 'true',
-  logLevel: process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info'
+  logLevel: process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info',
+  redisUrl: process.env.REDIS_URL
 };
 
 var server = require('./server')(options);

--- a/web/server.js
+++ b/web/server.js
@@ -18,15 +18,26 @@ var passTest = new PassTest({
 });
 
 module.exports = function(options) {
-  var server = new Hapi.Server({
+  var serverConfig = {
     debug: options.debug,
     connections: {
       routes: {
         security: true
       }
     }
-  });
+  };
 
+  if ( options.redisUrl ) {
+    var redisUrl = require('redis-url').parse(options.redisUrl);
+    serverConfig.cache = {
+      engine: require('catbox-redis'),
+      host: redisUrl.hostname,
+      port: redisUrl.port,
+      password: redisUrl.password
+    };
+  }
+
+  var server = new Hapi.Server(serverConfig);
 
   server.connection({
     host: options.host,

--- a/web/server.js
+++ b/web/server.js
@@ -130,9 +130,14 @@ module.exports = function(options) {
     Hoek.assert(!err, err);
   });
 
-  var account = require('../lib/account')({
-    loginAPI: options.loginAPI,
-    uri: options.uri
+  server.register({
+    register: require('../lib/account'),
+    options: {
+      loginAPI: options.loginAPI,
+      uri: options.uri
+    }
+  }, function(err) {
+    Hoek.assert(!err, err);
   });
 
   var oauthDb = new OAuthDB(options.oauth_clients, options.authCodes, options.accessTokens);
@@ -348,7 +353,7 @@ module.exports = function(options) {
             assign: 'authCode',
             method: function(request, reply) {
               if ( request.pre.grant_type === 'password' ) {
-                return account.verifyPassword(request, function(err, json) {
+                return server.methods.account.verifyPassword(request, function(err, json) {
                   if ( err ) {
                     return reply(err);
                   }
@@ -393,7 +398,7 @@ module.exports = function(options) {
           {
             assign: 'user',
             method: function(request, reply) {
-              account.verifyPassword(request, function(err, json) {
+              server.methods.account.verifyPassword(request, function(err, json) {
                 if ( err ) {
                   return reply(err);
                 }
@@ -416,7 +421,7 @@ module.exports = function(options) {
         auth: false
       },
       handler: function(request, reply) {
-        account.requestReset(request, function(err, json) {
+        server.methods.account.requestReset(request, function(err, json) {
           if ( err ) {
             return reply(err);
           }
@@ -432,7 +437,7 @@ module.exports = function(options) {
         auth: false
       },
       handler: function(request, reply) {
-        account.resetPassword(request, function(err, json) {
+        server.methods.account.resetPassword(request, function(err, json) {
           if ( err ) {
             return reply(err);
           }
@@ -497,7 +502,7 @@ module.exports = function(options) {
         ]
       },
       handler: function(request, reply) {
-        account.createUser(request, function(err, json) {
+        server.methods.account.createUser(request, function(err, json) {
           if ( err ) {
             err.output.payload.data = err.data;
             return reply(err);
@@ -590,7 +595,7 @@ module.exports = function(options) {
           {
             assign: 'user',
             method: function(request, reply) {
-              account.getUser(request.pre.token.user_id, function(err, json) {
+              server.methods.account.getUser(request.pre.token.user_id, function(err, json) {
                 if ( err ) {
                   return reply(Boom.badImplementation(err));
                 }
@@ -616,7 +621,7 @@ module.exports = function(options) {
         auth: false
       },
       handler: function(request, reply) {
-        account.requestMigrateEmail(request, function(err, json) {
+        server.methods.account.requestMigrateEmail(request, function(err, json) {
           if ( err ) {
             return reply(Boom.badImplementation(err));
           }
@@ -656,7 +661,7 @@ module.exports = function(options) {
           {
             assign: 'isValidToken',
             method: function(request, reply) {
-              account.verifyToken(request, function(err, json) {
+              server.methods.account.verifyToken(request, function(err, json) {
                 if ( err ) {
                   return reply(err);
                 }
@@ -668,7 +673,7 @@ module.exports = function(options) {
           {
             assign: 'user',
             method: function(request, reply) {
-              account.setPassword(
+              server.methods.account.setPassword(
                 request,
                 request.pre.uid,
                 request.pre.password,
@@ -696,7 +701,7 @@ module.exports = function(options) {
         auth: false
       },
       handler: function(request, reply) {
-        account.checkUsername(request, function(err, json) {
+        server.methods.account.checkUsername(request, function(err, json) {
           if ( err ) {
             return reply(err);
           }


### PR DESCRIPTION
Fixes #367 

Two commits here:

The first commit refactors the "account.js" file into a Hapi module that exposes its methods as Hapi server methods (this makes adding caching where we want it much easier) The methods don't change, only how they're called and required into the server.

The second commit adds in the caching to getUser, cached for 24 hours, stale in one, with a staleTimeout of 100ms (return cached value if refresh takes any longer). If there's an error or no user is returned, the result is not cached by passing "0" into the callback as the third argument.