### PR TITLE
there is no phantomjs 1.9.7-15, it goes from 1.9.7-14 to 1.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "mofo-style": "latest",
     "ncp": "^2.0.0",
     "npm-run-all": "^1.1.3",
-    "phantomjs": "1.9.7-15"
+    "phantomjs": "1.9.7-14"
   },
   "engines": {
     "npm": "^2.5.1",


### PR DESCRIPTION
The phantom module as required right now fails because there is no `1.9.7-15`, so nothing gets installed and mocha-phantom dies trying to use a non-existent version of Phantom.