### PR TITLE
added an OPTIONS handler to deal with the CORS check for /user

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -547,10 +547,21 @@ module.exports = function(options) {
       }
     },
     {
+      method: 'OPTIONS',
+      path: '/user',
+      config: {
+        cors: true
+      },
+      handler: function(request, reply) {
+        reply();
+      }
+    },
+    {
       method: 'GET',
       path: '/user',
       config: {
         auth: false,
+        cors: true,
         pre: [
           {
             assign: 'requestToken',


### PR DESCRIPTION
without the OPTIONS entry for the /user route, the browser will fail its preflight CORS check on the /user route, and will never allow the GET operation to go through