### PR TITLE
Added a basic password strength meter

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "mofo-style": "latest",
     "ncp": "^2.0.0",
     "npm-run-all": "^1.1.3",
-    "phantomjs": "1.9.7-15"
+    "phantomjs": "1.9.7-15",
+    "zxcvbn": "^3.4.0"
   },
   "engines": {
     "npm": "^2.5.1",

--- a/templates/components/form/form.jsx
+++ b/templates/components/form/form.jsx
@@ -121,6 +121,11 @@ var Form = React.createClass({
     });
 
   },
+  handleKeyUp: function(event) {
+   if ( this.props.onInputKeyUp ) {
+     this.props.onInputKeyUp(event.currentTarget.id, event.currentTarget.value);
+    }
+  },
   buildFormElement: function(key, i) {
     // we always expect this.props.fields[i] to be one object with one property.
     var id = Object.keys(this.props.fields[i])[0];
@@ -142,11 +147,18 @@ var Form = React.createClass({
              valueLink={this.linkState(id)}
              defaultValue={this.props.defaultUsername}
              onBlur={this.handleValidation(id, this.dirty(id, this.props.origin))}
+             onKeyUp={this.handleKeyUp}
              className={this.getInputClasses(id, isValid)}
              disabled={value.disabled ? "disabled" : false}
              autoFocus={value.focus ? true : false}
       />
     );
+
+    if (value.strengthBar === true) {
+        var strengthBar = (
+            <div ref={id+'StrengthBar'} className='password-strength-bar'><div></div></div>
+        );
+    }
 
     if (value.type === 'checkbox') {
       var input = (
@@ -173,12 +185,15 @@ var Form = React.createClass({
     var errorTooltip = <ToolTip ref="tooltip" className="warning" message={errorMessage}/>;
 
     return (
-     <label ref={id+'Label'} className={this.getLabelClasses(id, isValid)} key={id} htmlFor={id}>
-        {!isValid ? errorTooltip : false}
-        {value.label && value.labelPosition==='before' ? value.label : false}
-        {input}
-        {value.label && value.labelPosition==='after' ? value.label : false}
-     </label>
+    <div>
+        <label ref={id+'Label'} className={this.getLabelClasses(id, isValid)} key={id} htmlFor={id}>
+            {!isValid ? errorTooltip : false}
+            {value.label && value.labelPosition==='before' ? value.label : false}
+            {input}
+            {value.label && value.labelPosition==='after' ? value.label : false}
+        </label>
+        {value.strengthBar === true ? strengthBar : false}
+    </div>
     );
   },
   render: function() {
@@ -221,6 +236,9 @@ var Form = React.createClass({
     classes[this.errorClass] = !isValid;
     classes[this.validClass] = (field !== 'feedback' && (this.state.dirty[field] && isValid) || this.passChecked)
     return React.addons.classSet(classes);
+  },
+  getStrengthBar: function(field) {
+    return this.refs[field + "StrengthBar"];
   },
   getIconClass: function(field) {
     return Form.iconLabels[field];

--- a/templates/less/pages/signup.less
+++ b/templates/less/pages/signup.less
@@ -17,6 +17,53 @@
       max-width: 170px;
     }
   }
+  
+  .password-strength-bar {
+    height: 20px;
+    background-color: #fff;
+    width: 100%;
+    color: #000;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    margin-bottom: 10px;
+  }
+    .password-strength-bar > div {
+        background-color: currentColor;
+        width: 0;
+        height: 18px;
+        float: left;
+    }
+        .password-strength-bar[data-strength="0"],
+        .password-strength-bar[data-strength="25"] {
+          color: red;
+        }
+          .password-strength-bar[data-strength="0"] > div {
+            width: 0;
+          }
+          .password-strength-bar[data-strength="25"] > div {
+            width: 25%;
+          }
+        
+        .password-strength-bar[data-strength="50"] {
+          color: yellow;
+        }
+            .password-strength-bar[data-strength="50"] > div {
+              width: 50%;
+            }
+
+        .password-strength-bar[data-strength="75"] {
+          color: #39A9E7;
+        }
+            .password-strength-bar[data-strength="75"] > div {
+              width: 75%;
+            }
+
+        .password-strength-bar[data-strength="100"] {
+          color: #53C0A3;
+        }
+            .password-strength-bar[data-strength="100"] > div {
+              width: 100%;
+            }
 
 
   .inputBox {

--- a/templates/lib/api.jsx
+++ b/templates/lib/api.jsx
@@ -88,6 +88,7 @@ module.exports = {
     var strength = zxcvbn(password);
 
     var tooLong = password.length > MAX_PASSWORD_LEN,
+        tooShort = password.length < MIN_PASSWORD_LEN,
         strengthValid = strength.score > 2;
 
     WebmakerActions.setPasswordStrength({ 'percent': (strength.score / 4) * 100 });
@@ -96,6 +97,9 @@ module.exports = {
     }
     if (strength.score <= 2) {
       WebmakerActions.displayError({ 'field': 'password', 'message': 'Your password would only take ' + strength.crack_time_display + ' to crack. Please pick a stronger password.' });
+    }
+    if (tooShort) {
+      WebmakerActions.displayError({'field': 'password', 'message': 'Password must be at least 8 characters long.'});
     }
     if (tooLong) {
       WebmakerActions.displayError({'field': 'password', 'message': 'Password cannot be more than 128 characters long.'});
@@ -108,7 +112,7 @@ module.exports = {
     } else if (!username) {
       WebmakerActions.displayError({'field': 'username', 'message': 'Please specify a username.'});
     }
-    if (strengthValid && containUserValid && !tooLong) {
+    if (strengthValid && containUserValid && !tooShort && !tooLong) {
       this.setFormState({field: 'password'});
     }
   }

--- a/templates/lib/webmaker-actions.jsx
+++ b/templates/lib/webmaker-actions.jsx
@@ -5,7 +5,8 @@ var Constants = {
   "FORM_ERROR": "FORM_ERROR",
   "FORM_WARNING": "FORM_WARNING",
   "FORM_VALID": "FORM_VALID",
-  "FORM_VALIDATION": "FORM_VALIDATION"
+  "FORM_VALIDATION": "FORM_VALIDATION",
+  "FORM_PASSWORD_STRENGTH": "FORM_PASSWORD_STRENGTH"
 };
 var WebmakerActions = Object.assign({}, EventEmitter.prototype, {
   displayError: function(data) {
@@ -30,6 +31,12 @@ var WebmakerActions = Object.assign({}, EventEmitter.prototype, {
     WebmakerDispatcher.dispatch({
       'data': data,
       'actionType': Constants.FORM_VALID
+    });
+  },
+  setPasswordStrength: function(data) {
+    WebmakerDispatcher.dispatch({
+      'data': data,
+      'actionType': Constants.FORM_PASSWORD_STRENGTH
     });
   },
   addListener: function(actionType, callback) {
@@ -57,9 +64,14 @@ WebmakerDispatcher.register(function(payload) {
       WebmakerActions.emitEvent(Constants.FORM_WARNING, payload.data);
       break;
 
-      case Constants.FORM_VALID:
-        WebmakerActions.emitEvent(Constants.FORM_VALID, payload.data);
-        break;
+    case Constants.FORM_VALID:
+      WebmakerActions.emitEvent(Constants.FORM_VALID, payload.data);
+      break;
+
+    case Constants.FORM_PASSWORD_STRENGTH:
+      WebmakerActions.emitEvent(Constants.FORM_PASSWORD_STRENGTH, payload.data);
+      break;
+
     default:
       // no op
   }

--- a/templates/pages/signup.jsx
+++ b/templates/pages/signup.jsx
@@ -36,7 +36,8 @@ var fieldValues = [
       'type': 'password',
       'validator': 'password',
       'label': false,
-      'tabIndex': '3'
+      'tabIndex': '3',
+      'strengthBar': true
     }
   },
   {
@@ -59,11 +60,13 @@ var Signup = React.createClass({
     document.body.className = "signup-bg";
     WebmakerActions.addListener('FORM_ERROR', this.setFormState);
     WebmakerActions.addListener('FORM_VALIDATION', this.handleFormData);
+    WebmakerActions.addListener('FORM_PASSWORD_STRENGTH', this.setFormPasswordStrength);
   },
   componentWillUnmount: function() {
     document.body.className = "";
     WebmakerActions.deleteListener('FORM_ERROR', this.setFormState);
     WebmakerActions.deleteListener('FORM_VALIDATION', this.handleFormData);
+    WebmakerActions.deleteListener('FORM_PASSWORD_STRENGTH', this.setFormPasswordStrength);
   },
   render: function() {
     var queryObj = Url.parse(window.location.href, true).query;
@@ -80,9 +83,11 @@ var Signup = React.createClass({
                 validators={fieldValidators}
                 origin="Signup"
                 onInputBlur={this.handleBlur}
+                onInputKeyUp={this.handleKeyUp}
                 autoComplete="off"
           />
         </div>
+        
         <div className="commit">
           <IconText iconClass="agreement" textClass="eula">
             By signing up, I agree to Webmaker&lsquo;s <a tabIndex="5" href="//webmaker.org/en-US/terms" className="underline">Terms of Service</a> and <a tabIndex="6" href="//webmaker.org/en-US/privacy" className="underline">Privacy Policy</a>.
@@ -95,8 +100,16 @@ var Signup = React.createClass({
   setFormState: function(data) {
     this.refs.userform.setState({['valid_' +data.field]: false});
   },
+  setFormPasswordStrength: function (data) {
+    this.refs.userform.getStrengthBar("password").getDOMNode().dataset.strength = data.percent;
+  },
   processSignup: function(evt) {
     this.refs.userform.processFormData(evt);
+  },
+  handleKeyUp: function(fieldName, value) {
+    if (fieldName === 'password') {
+      this.refs.userform.validatePassword(value, true);
+    }
   },
   handleBlur: function(fieldName, value) {
     var userform = this.refs.userform;


### PR DESCRIPTION
See issue #318 and https://github.com/mozilla/api.webmaker.org/issues/178, using zxcvbn to add a password meter instead of specific character requirements. Anything with a score < 2/4 will be blocked from signing up.

I haven't been able to test actually creating a new account with this, and it can be a little bit buggy (especially if you click the Password field then click away then enter a password, it doesn't recognize that a password has been entered until you click away [though I think it's always been like that?])

Also note that I've left the check for passwords to be at least 8 characters, although I would suggest changing that to 6 characters as long as zxcvbn claims the password is secure enough.


![0/4 Password](https://cloud.githubusercontent.com/assets/1159057/9868332/4c11e684-5b2c-11e5-9525-1453ee63f74f.JPG)
![1/4 Password](https://cloud.githubusercontent.com/assets/1159057/9868331/4c0d3ee0-5b2c-11e5-9f80-47d4ba3851fc.JPG)
![2/4 Password](https://cloud.githubusercontent.com/assets/1159057/9868329/4c099bc8-5b2c-11e5-92d3-1207ba49dcd7.JPG)
![3/4 Password](https://cloud.githubusercontent.com/assets/1159057/9868328/4c077816-5b2c-11e5-9850-fd049ba2d6ad.JPG)
![4/4 Password](https://cloud.githubusercontent.com/assets/1159057/9868330/4c0d2112-5b2c-11e5-972d-03f6035a1f6c.JPG)