### PR TITLE
auth:false for OPTIONS

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -561,16 +561,6 @@ module.exports = function(options) {
       }
     },
     {
-      method: 'OPTIONS',
-      path: '/user',
-      config: {
-        cors: true
-      },
-      handler: function(request, reply) {
-        reply();
-      }
-    },
-    {
       method: 'GET',
       path: '/user',
       config: {


### PR DESCRIPTION
Hapi 11 changed how OPTIONS preflight calls are handled, and the explicit configuration might be throwing things off.