### PR TITLE
fix autoless dying on too-new a version of less

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "isomorphic-fetch": "2.0.1",
     "joi": "6.0.8",
     "jsx-loader": "0.12.2",
+    "less": "1.7.5",
     "newrelic": "1.20.1",
     "pass-test": "1.0.3",
     "pg": "4.3.0",


### PR DESCRIPTION
fixes https://github.com/mozilla/id.webmaker.org/issues/413

`autoless` needs less version 1.7.5 of `less`, but something else installs a `less` version 2.4.0, and `autoless` seems to not use its "own" version of `less` but simply that top level too-modern version from the top level node_modules dir. Thus, everything breaks.

This PR adds an explicit requirement for `less` 1.7.5, causing whatever needs 2.4.0 to install that locally, so that `autoless` no longer breaks all the things.

That said, ditching `autoless` and just using normal watching is probably a far more permanent solution.