### PR TITLE
Fix oauth doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ You can configure the following environment variables:
 
 ## Using OAuth2
 
-For information on creating an OAuth2 application that relies on this server, see [`docs/oauth.md`](https://github.com/mozilla/id.webmaker.org/blob/develop/docs/oauth.md).
+For information on creating an OAuth2 application that relies on this server, see [`docs/oauth.md`](docs/oauth.md).


### PR DESCRIPTION
Current link is 404, fixed to relative link to file in repo.