### PR TITLE
Set a reCAPTCHA failure threshold

### DIFF
--- a/templates/pages/signup.jsx
+++ b/templates/pages/signup.jsx
@@ -183,6 +183,7 @@ var Signup = React.createClass({
         }
 
         if( response.status >= 400 ) {
+          console.error('You have failed the reCAPTCHA test');
           that.enableButton();
         }
 

--- a/web/index.js
+++ b/web/index.js
@@ -17,7 +17,8 @@ var options = {
   logLevel: process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info',
   redisUrl: process.env.REDIS_URL,
   recaptchaDisabled: process.env.RECAPTCHA_DISABLED === 'true',
-  recaptchaSecretKey: process.env.RECAPTCHA_SECRET_KEY
+  recaptchaSecretKey: process.env.RECAPTCHA_SECRET_KEY,
+  recaptchaFailureThreshold: process.env.RECAPTCHA_FAILURE_THRESHOLD || 0.5
 };
 
 const start = async () => {

--- a/web/server.js
+++ b/web/server.js
@@ -521,7 +521,7 @@ module.exports = async function server(options) {
                 }
 
                 // disallow scores of less than 0.5  (see "interpreting the score" on https://developers.google.com/recaptcha/docs/v3)
-                if (body.score < 0.5) {
+                if (body.score < options.recaptchaFailureThreshold) {
                   return reject(new Boom(403, 'reCAPTCHA test failed'));
                 }
 

--- a/web/server.js
+++ b/web/server.js
@@ -520,6 +520,11 @@ module.exports = async function server(options) {
                   return reject(err);
                 }
 
+                // disallow scores of less than 0.5  (see "interpreting the score" on https://developers.google.com/recaptcha/docs/v3)
+                if (body.score < 0.5) {
+                  return reject(new Boom(403, 'reCAPTCHA test failed'));
+                }
+
                 if (!body.success) {
                   reject(new Boom(403, body.errorCodes, body));
                 }


### PR DESCRIPTION
This PR updates the reCAPTCHA check server side to look at the score. the threshold for failure is configurable, and will default to 0.5. 