### PR TITLE
Peg scooter version to patch releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-router-viewports": "0.0.4",
     "react-validation-mixin": "^5.4.0",
     "redis-url": "1.2.1",
-    "scooter": "^5.0.0",
+    "scooter": "~5.0.0",
     "should": "5.2.0",
     "webpack": "1.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "5.0.0",
     "babel-runtime": "^6.26.0",
-    "blankie": "^4.0.0",
+    "blankie": "~4.0.0",
     "boom": "^7.1.1",
     "bootstrap": "3.3.4",
     "bunyan": "^1.8.12",

--- a/test/web.js
+++ b/test/web.js
@@ -84,7 +84,7 @@ lab.experiment("OAuth", function() {
       "img-src 'self' data: https://www.google-analytics.com http://www.google-analytics.com;" +
       "script-src 'self' 'unsafe-eval' https://www.google-analytics.com http://www.google-analytics.com " +
       "https://www.google.com/recaptcha/api.js https://www.gstatic.com/recaptcha/api2/;" + 
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;worker-src 'self'"
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
     );
   });
 


### PR DESCRIPTION
I noticed that staging crashes with an error with dependencies saying blankie depends on scooter to run.

Apparently both blankie and scooter added a breaking change in their minor release 🙄 where you need to refer to each package as @hapi/packagename.

Instead of updating those and figuring out what will break, I'm pegging both of their versions to when they worked with the original name.